### PR TITLE
fix: restore dev branch CNAME to dev.diabsurance.de

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-diabsurance.de
+dev.diabsurance.de


### PR DESCRIPTION
The fast-forward of dev to master earlier today overwrote the dev branch's CNAME (which is dev.diabsurance.de) with master's CNAME (diabsurance.de). The .gitattributes "CNAME merge=keep-ours" strategy is supposed to prevent this on merges, but fast-forwards bypass it (no merge happens, just a pointer move). Result: dev.diabsurance.de was returning GitHub's default 404 because the diabsurance_dev mirror repo received a CNAME claiming diabsurance.de (already taken by the main repo) instead of dev.diabsurance.de.

Restore the correct dev-branch CNAME. Going forward, use `git merge origin/master` (no --ff-only) when syncing dev with master so the keep-ours strategy preserves the dev CNAME automatically.